### PR TITLE
Added three RPC methods to manage the set of SEM rules

### DIFF
--- a/light/proxy/routes.go
+++ b/light/proxy/routes.go
@@ -49,7 +49,11 @@ func RPCRoutes(c *lrpc.Client) map[string]*rpcserver.RPCFunc {
 
 		// evidence API
 		"broadcast_evidence": rpcserver.NewRPCFunc(makeBroadcastEvidenceFunc(c), "evidence"),
-		//TODO: extend
+
+		// SEM (Selective Entity Monitoring) API
+		"sem_add_rule":   rpcserver.NewRPCFunc(makeSemAddRuleFunc(c), "entity_type,value"),
+		"sem_delete_all": rpcserver.NewRPCFunc(makeSemDeleteAllFunc(c), ""),
+		"sem_status":     rpcserver.NewRPCFunc(makeSemStatusFunc(c), ""),
 	}
 }
 
@@ -297,5 +301,29 @@ type rpcBroadcastEvidenceFunc func(ctx *rpctypes.Context, ev types.Evidence) (*c
 func makeBroadcastEvidenceFunc(c *lrpc.Client) rpcBroadcastEvidenceFunc {
 	return func(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 		return c.BroadcastEvidence(ctx.Context(), ev)
+	}
+}
+
+type rpcSemAddRuleFunc func(ctx *rpctypes.Context, entityType uint, value []byte) (*ctypes.ResultSemAddRule, error)
+
+func makeSemAddRuleFunc(c *lrpc.Client) rpcSemAddRuleFunc {
+	return func(ctx *rpctypes.Context, entityType uint, value []byte) (*ctypes.ResultSemAddRule, error) {
+		return c.SemAddRule(ctx.Context(), entityType, value)
+	}
+}
+
+type rpcSemDeleteAllFunc func(ctx *rpctypes.Context) (*ctypes.ResultSemDeleteAll, error)
+
+func makeSemDeleteAllFunc(c *lrpc.Client) rpcSemDeleteAllFunc {
+	return func(ctx *rpctypes.Context) (*ctypes.ResultSemDeleteAll, error) {
+		return c.SemDeleteAll(ctx.Context())
+	}
+}
+
+type rpcSemStatusFunc func(ctx *rpctypes.Context) (*ctypes.ResultSemStatus, error)
+
+func makeSemStatusFunc(c *lrpc.Client) rpcSemStatusFunc {
+	return func(ctx *rpctypes.Context) (*ctypes.ResultSemStatus, error) {
+		return c.SemStatus(ctx.Context())
 	}
 }

--- a/light/proxy/routes.go
+++ b/light/proxy/routes.go
@@ -49,6 +49,7 @@ func RPCRoutes(c *lrpc.Client) map[string]*rpcserver.RPCFunc {
 
 		// evidence API
 		"broadcast_evidence": rpcserver.NewRPCFunc(makeBroadcastEvidenceFunc(c), "evidence"),
+		//TODO: extend
 	}
 }
 

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -614,6 +614,21 @@ func (c *Client) UnsubscribeAllWS(ctx *rpctypes.Context) (*ctypes.ResultUnsubscr
 	return &ctypes.ResultUnsubscribe{}, nil
 }
 
+func (c *Client) SemAddRule(ctx context.Context, entityType uint, value []byte) (*ctypes.ResultSemAddRule, error) {
+	//TODO: Light client implementation has a logger, so extend light client interface to implement this function
+	return nil, errors.New("Light client does not implement SemAddRule method")
+}
+
+func (c *Client) SemDeleteAll(ctx context.Context) (*ctypes.ResultSemDeleteAll, error) {
+	//TODO: Light client implementation has a logger, so extend light client interface to implement this function
+	return nil, errors.New("Light client does not implement SemDeleteAll method")
+}
+
+func (c *Client) SemStatus(ctx context.Context) (*ctypes.ResultSemStatus, error) {
+	//TODO: Light client implementation has a logger, so extend light client interface to implement this function
+	return nil, errors.New("Light client does not implement SemStatus method")
+}
+
 // XXX: Copied from rpc/core/env.go
 const (
 	// see README

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -565,6 +565,41 @@ func (c *baseRPCClient) BroadcastEvidence(
 	return result, nil
 }
 
+func (c *baseRPCClient) SemAddRule(
+	ctx context.Context,
+	entityType uint,
+	value []byte,
+) (*ctypes.ResultSemAddRule, error) {
+	result := new(ctypes.ResultSemAddRule)
+	params := map[string]interface{}{
+		"entity_type": entityType,
+		"value":       value,
+	}
+	_, err := c.caller.Call(ctx, "sem_add_rule", params, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *baseRPCClient) SemDeleteAll(ctx context.Context) (*ctypes.ResultSemDeleteAll, error) {
+	result := new(ctypes.ResultSemDeleteAll)
+	_, err := c.caller.Call(ctx, "sem_delete_all", map[string]interface{}{}, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *baseRPCClient) SemStatus(ctx context.Context) (*ctypes.ResultSemStatus, error) {
+	result := new(ctypes.ResultSemStatus)
+	_, err := c.caller.Call(ctx, "sem_status", map[string]interface{}{}, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 //-----------------------------------------------------------------------------
 // WSEvents
 

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -41,6 +41,7 @@ type Client interface {
 	StatusClient
 	EvidenceClient
 	MempoolClient
+	SemClient
 }
 
 // ABCIClient groups together the functionality that principally affects the
@@ -141,6 +142,13 @@ type MempoolClient interface {
 // behaviour.
 type EvidenceClient interface {
 	BroadcastEvidence(context.Context, types.Evidence) (*ctypes.ResultBroadcastEvidence, error)
+}
+
+// SemClient is used to manage the set of Selective Entity Monitoring (SEM) rules
+type SemClient interface {
+	SemAddRule(ctx context.Context, entityType uint, value []byte) (*ctypes.ResultSemAddRule, error)
+	SemDeleteAll(ctx context.Context) (*ctypes.ResultSemDeleteAll, error)
+	SemStatus(ctx context.Context) (*ctypes.ResultSemStatus, error)
 }
 
 // RemoteClient is a Client, which can also return the remote network address.

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -299,3 +299,19 @@ func (c *Local) Unsubscribe(ctx context.Context, subscriber, query string) error
 func (c *Local) UnsubscribeAll(ctx context.Context, subscriber string) error {
 	return c.EventBus.UnsubscribeAll(ctx, subscriber)
 }
+
+func (c *Local) SemAddRule(
+	ctx context.Context,
+	entityType uint,
+	value []byte,
+) (*ctypes.ResultSemAddRule, error) {
+	return core.SemAddRule(c.ctx, entityType, value)
+}
+
+func (c *Local) SemDeleteAll(ctx context.Context) (*ctypes.ResultSemDeleteAll, error) {
+	return core.SemDeleteAll(c.ctx)
+}
+
+func (c *Local) SemStatus(ctx context.Context) (*ctypes.ResultSemStatus, error) {
+	return core.SemStatus(c.ctx)
+}

--- a/rpc/client/mock/client.go
+++ b/rpc/client/mock/client.go
@@ -176,3 +176,18 @@ func (c Client) Validators(ctx context.Context, height *int64, page, perPage *in
 func (c Client) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 	return core.BroadcastEvidence(&rpctypes.Context{}, ev)
 }
+
+func (c Client) SemAddRule(ctx context.Context,
+	entityType uint,
+	value []byte,
+) (*ctypes.ResultSemAddRule, error) {
+	return core.SemAddRule(&rpctypes.Context{}, entityType, value)
+}
+
+func (c Client) SemDeleteAll(ctx context.Context) (*ctypes.ResultSemDeleteAll, error) {
+	return core.SemDeleteAll(&rpctypes.Context{})
+}
+
+func (c Client) SemStatus(ctx context.Context) (*ctypes.ResultSemStatus, error) {
+	return core.SemStatus(&rpctypes.Context{})
+}

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -46,11 +46,6 @@ var Routes = map[string]*rpc.RPCFunc{
 
 	// evidence API
 	"broadcast_evidence": rpc.NewRPCFunc(BroadcastEvidence, "evidence"),
-
-	// SEM (Selective Entity Monitoring) API
-	"sem_add_rule":   rpc.NewRPCFunc(SemAddRule, "entity_type,value"),
-	"sem_delete_all": rpc.NewRPCFunc(SemDeleteAll, ""),
-	"sem_status":     rpc.NewRPCFunc(SemStatus, ""),
 }
 
 // AddUnsafeRoutes adds unsafe routes.
@@ -59,4 +54,9 @@ func AddUnsafeRoutes() {
 	Routes["dial_seeds"] = rpc.NewRPCFunc(UnsafeDialSeeds, "seeds")
 	Routes["dial_peers"] = rpc.NewRPCFunc(UnsafeDialPeers, "peers,persistent,unconditional,private")
 	Routes["unsafe_flush_mempool"] = rpc.NewRPCFunc(UnsafeFlushMempool, "")
+
+	// SEM (Selective Entity Monitoring) API
+	Routes["sem_add_rule"] = rpc.NewRPCFunc(SemAddRule, "entity_type,value")
+	Routes["sem_delete_all"] = rpc.NewRPCFunc(SemDeleteAll, "")
+	Routes["sem_status"] = rpc.NewRPCFunc(SemStatus, "")
 }

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -46,6 +46,11 @@ var Routes = map[string]*rpc.RPCFunc{
 
 	// evidence API
 	"broadcast_evidence": rpc.NewRPCFunc(BroadcastEvidence, "evidence"),
+
+	// SEM (Selective Entity Monitoring) API
+	"sem_add_rule":   rpc.NewRPCFunc(SemAddRule, "entity_type,value"),
+	"sem_delete_all": rpc.NewRPCFunc(SemDeleteAll, ""),
+	"sem_status":     rpc.NewRPCFunc(SemStatus, ""),
 }
 
 // AddUnsafeRoutes adds unsafe routes.

--- a/rpc/core/sem_logging.go
+++ b/rpc/core/sem_logging.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"errors"
+
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+)
+
+// TODO: This should disappear and use sem backend instead
+var rules = []ctypes.SemRule{}
+
+// SemAddRule adds a rule referring to an entity to be monitored
+// More: https://docs.cometbft.com/v0.34/rpc/#/Sem/sem_add_rule
+func SemAddRule(ctx *rpctypes.Context, entityType uint, value []byte) (*ctypes.ResultSemAddRule, error) {
+	if entityType == 0 {
+		return nil, errors.New("zero value not allowed as entity type")
+	}
+
+	newRule := ctypes.SemRule{EntityType: entityType, Value: value}
+	rules = append(rules, newRule)
+
+	return &ctypes.ResultSemAddRule{}, nil
+}
+
+func SemDeleteAll(ctx *rpctypes.Context) (*ctypes.ResultSemDeleteAll, error) {
+	rules = []ctypes.SemRule{}
+	return &ctypes.ResultSemDeleteAll{}, nil
+}
+
+func SemStatus(ctx *rpctypes.Context) (*ctypes.ResultSemStatus, error) {
+	resRules := make([]ctypes.SemRule, len(rules))
+	copy(resRules, rules)
+	return &ctypes.ResultSemStatus{Rules: resRules}, nil
+}

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -234,6 +234,16 @@ type ResultBroadcastEvidence struct {
 	Hash []byte `json:"hash"`
 }
 
+// TODO: This type should come from backend
+type SemRule struct {
+	EntityType uint   `json:"entity_type"`
+	Value      []byte `json:"value"`
+}
+
+type ResultSemStatus struct {
+	Rules []SemRule `json:"rules"`
+}
+
 // empty results
 type (
 	ResultUnsafeFlushMempool struct{}
@@ -241,6 +251,8 @@ type (
 	ResultSubscribe          struct{}
 	ResultUnsubscribe        struct{}
 	ResultHealth             struct{}
+	ResultSemAddRule         struct{}
+	ResultSemDeleteAll       struct{}
 )
 
 // Event data from a subscription

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -82,6 +82,8 @@ tags:
     description: Evidence APIs
   - name: Unsafe
     description: Unsafe APIs
+  - name: Sem
+    description: Sem-related APIs (SEM is Selective Entity Monitoring)
 paths:
   /broadcast_tx_sync:
     get:
@@ -1090,6 +1092,88 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /sem_add_rule:
+    get:
+      summary: Add a new SEM rule
+      operationId: sem_add_rule
+      parameters:
+        - in: query
+          name: entity_type
+          required: true
+          description: type of the entity to monitor.
+          schema:
+            type: integer
+            example: 1
+        - in: query
+          name: value
+          required: true
+          description: the value to start watching.
+          schema:
+            type: string
+            example: "123"
+      tags:
+        - Sem
+      description: |
+        Add a watch rule to Semantic Entity Monitoring (SEM).
+
+        The `entity_type` field denotes which entity the RPC call refers to.
+        The `value` field is a serialized representation of the entity value.
+      responses:
+        "200":
+          description: SEM rule added.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+        "500":
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /sem_delete_all:
+    get:
+      summary: Delete all SEM rules
+      operationId: sem_delete_all
+      tags:
+        - Sem
+      description: |
+        Delete all previously added rules to Semantic Entity Monitoring (SEM).
+      responses:
+        "200":
+          description: All SEM rules deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+        "500":
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /sem_status:
+    get:
+      summary: Get SEM status
+      operationId: sem_status
+      tags:
+        - Sem
+        - Info
+      description: |
+        Get the status of Semantic Entity Monitoring (SEM).
+      responses:
+        "200":
+          description: SEM status.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SemStatusResponse"
+        "500":
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
 components:
   schemas:
@@ -1475,6 +1559,32 @@ components:
           properties:
             result:
               $ref: "#/components/schemas/BlockComplete"
+
+    SemRule:
+      type: object
+      properties:
+        entity_type:
+          type: integer
+          example: 1
+        value:
+          type: string
+          example: "abc"
+    SemStatus:
+      description: SEM Status Response
+      type: object
+      properties:
+        rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/SemRule"
+    SemStatusResponse:
+      description: SEM Status Response
+      allOf:
+        - $ref: "#/components/schemas/JSONRPC"
+        - type: object
+          properties:
+            result:
+              $ref: "#/components/schemas/SemStatus"
 
     ################## FROM NOW ON NEEDS REFACTOR ##################
     BlockResultsResponse:

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -252,6 +252,7 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	if node.Prometheus {
 		cfg.Instrumentation.Prometheus = true
 	}
+	cfg.RPC.Unsafe = true
 
 	return cfg, nil
 }


### PR DESCRIPTION
At the moment, the three methods just implement a dummy SEM rule list, which will have to be removed and hooked into the actual SEM backend implementation.

Notice the commit 451078d301f4142c21d4346bdbb59ff62231213e, adding the methods also on the light client. Rules will be redirected to the light client implementation, which uses a logger, but that will require extending the `LightClient` interface (not obvious at this time if it's worth the trouble). If we decide not to support the light client, we can easily revert that commit.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

